### PR TITLE
Install daemon.conf to /etc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ set (GETTEXT_PACKAGE "${CMAKE_PROJECT_NAME}-plug")
 
 list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
+set (DAEMON_CONF_DIR "${CMAKE_INSTALL_FULL_SYSCONFDIR}/pantheon-parental-controls")
+
 # Configure file
 configure_file (${CMAKE_SOURCE_DIR}/config.vala.cmake ${CMAKE_BINARY_DIR}/src/config.vala)
 configure_file (${CMAKE_SOURCE_DIR}/src/shared/Constants.vala.cmake ${CMAKE_SOURCE_DIR}/src/shared/Constants.vala)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -2,7 +2,7 @@ configure_file (org.pantheon.switchboard.parental-controls.policy.cmake ${CMAKE_
 configure_file (org.pantheon.ParentalControls.service.cmake ${CMAKE_CURRENT_BINARY_DIR}/org.pantheon.ParentalControls.service)
 configure_file (pantheon-parental-controls.service.cmake ${CMAKE_CURRENT_BINARY_DIR}/data/pantheon-parental-controls.service)
 
-install (FILES daemon.conf DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pantheon-parental-controls)
+install (FILES daemon.conf DESTINATION ${DAEMON_CONF_DIR})
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/data/org.pantheon.switchboard.parental-controls.policy DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/polkit-1/actions/)
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/org.pantheon.ParentalControls.service DESTINATION share/dbus-1/system-services)
 install (FILES org.pantheon.ParentalControls.conf DESTINATION /etc/dbus-1/system.d)

--- a/src/shared/Constants.vala.cmake
+++ b/src/shared/Constants.vala.cmake
@@ -31,7 +31,7 @@ namespace PC.Constants {
     public const string PLANK_CONF_DIR = "/.config/plank/dock1/settings";
     public const string PLANK_CONF_GROUP = "PlankDockPreferences";
     public const string PLANK_CONF_LOCK_ITEMS_KEY = "LockItems";
-    public const string DAEMON_CONF_FILE = "@CMAKE_INSTALL_PREFIX@/share/pantheon-parental-controls/daemon.conf";
+    public const string DAEMON_CONF_FILE = "@DAEMON_CONF_DIR@/daemon.conf";
     public const string[] DAEMON_IGNORED_USERS = { "lightdm" };
     public const string DAEMON_GROUP = "PCDaemon";
     public const string DAEMON_KEY_ACTIVE = "Active";


### PR DESCRIPTION
The trunk installs `daemon.conf` to `/usr/share/pantheon-parental-controls` which is wrong directory for system configs. This branch installs it to `/etc/pantheon-parental-controls` and uses `CMAKE_INSTALL_FULL_SYSCONFDIR` variable to define `/etc/`.