### PR TITLE
Fix #32

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -13,10 +13,10 @@
 	dh $@ --with systemd
 
 override_dh_systemd_enable:
-	dh_systemd_enable -ppantheon-parental-controls
+	dh_systemd_enable -pswitchboard-plug-parental-controls
 
 override_dh_systemd_start:
-	dh_systemd_start -ppantheon-parental-controls
+	dh_systemd_start -pswitchboard-plug-parental-controls
 
 override_dh_strip:
 	dh_strip --dbg-package=switchboard-plug-parental-controls-dbg


### PR DESCRIPTION
debian/rules use debhelper dh_systemd_<enable/start> to install  pantheon-parental-controls.service 
with -p option to specify the package which own service. 
Currently the name of the service has been passed to this option instead of package name according debhelper man page. 
Since debhelper >= 10.9.2 the package building failed. 

This set -p option with switchboard-plug-parental-controls package name.