### PR TITLE
meson: use pkgconfig to determine correct systemd unit directory

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -9,7 +9,7 @@ configure_file(
     input: 'pantheon-parental-controls.service.in',
     output: '@BASENAME@',
     configuration: configuration_data,
-    install_dir: join_paths(get_option('libdir'),'systemd', 'system')
+    install_dir: systemd_dep.get_pkgconfig_variable('systemdsystemunitdir')
 )
 
 configure_file(

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,7 @@ gtk_dep = dependency('gtk+-3.0')
 gee_dep = dependency ('gee-0.8')
 polkit_dep = dependency('polkit-gobject-1')
 accountsservice_dep = dependency('accountsservice')
+systemd_dep = dependency('systemd')
 posix_dep = meson.get_compiler('vala').find_library('posix')
 
 subdir('data')


### PR DESCRIPTION
This should be the most portable way to determine the correct location of the systemd system units directory. It works as expected on fedora, and should work everywhere else, too.