### PR TITLE
Debian/control: Add libsystemd dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Build-Depends: debhelper (>= 10.5.1),
                libgtk-3-dev,
                libpolkit-gobject-1-dev,
                libswitchboard-2.0-dev,
+               libsystemd-dev,
                meson,
                valac (>= 0.34.1)
 Standards-Version: 4.1.1


### PR DESCRIPTION
Travis complains about missing this as Meson indicates we need it to build