### PR TITLE
Fix time restriction being applied even if time restriction disabled

### DIFF
--- a/src/plug/Widgets/ControlPage.vala
+++ b/src/plug/Widgets/ControlPage.vala
@@ -71,11 +71,7 @@ namespace PC.Widgets {
             unowned Polkit.Permission permission = Utils.get_permission ();
             if (permission.allowed) {
                 Utils.get_api ().set_user_daemon_active.begin (user.get_user_name (), active);
-                if (active) {
-                    time_limit_view.update_pam ();
-                } else {
-                    Utils.get_api ().remove_restriction_for_user.begin (user.get_user_name ());
-                }
+                time_limit_view.update_pam (active);
             }  
         }
 


### PR DESCRIPTION
Fixes #86.

Switching the master switch even when the time restriction switch was disabled resulted in explicit adding PAM rules to the config file. This has been fixed here.