### PR TITLE
Parental Controls → Screen Time & Limits

### DIFF
--- a/data/io.elementary.switchboard.parental-controls.appdata.xml.in
+++ b/data/io.elementary.switchboard.parental-controls.appdata.xml.in
@@ -2,7 +2,7 @@
 <component type="addon">
   <id>io.elementary.switchboard.parental-controls</id>
   <extends>io.elementary.switchboard</extends>
-  <name>Parental Controls Settings</name>
+  <name>Digital Wellbeing Settings</name>
   <summary>Configure time limits and restrict application usage</summary>
   <screenshots>
     <screenshot type="default">

--- a/data/io.elementary.switchboard.parental-controls.appdata.xml.in
+++ b/data/io.elementary.switchboard.parental-controls.appdata.xml.in
@@ -2,7 +2,7 @@
 <component type="addon">
   <id>io.elementary.switchboard.parental-controls</id>
   <extends>io.elementary.switchboard</extends>
-  <name>Digital Wellbeing Settings</name>
+  <name>Screen Time &amp; Limits Settings</name>
   <summary>Configure time limits and restrict application usage</summary>
   <screenshots>
     <screenshot type="default">

--- a/data/org.pantheon.switchboard.parental-controls.policy.in
+++ b/data/org.pantheon.switchboard.parental-controls.policy.in
@@ -7,8 +7,8 @@
   <vendor_url>https://elementary.io</vendor_url>
 
   <action id="org.pantheon.switchboard.parental-controls.administration">
-    <description gettext-domain="@GETTEXT_PACKAGE@">Manage Digital Wellbeing settings</description>
-    <message gettext-domain="@GETTEXT_PACKAGE@">Authentication is required to change Digital Wellbeing settings</message>
+    <description gettext-domain="@GETTEXT_PACKAGE@">Manage Screen Time &amp; Limits settings</description>
+    <message gettext-domain="@GETTEXT_PACKAGE@">Authentication is required to change Screen Time &amp; Limits settings</message>
     <icon_name>preferences-system-parental-controls</icon_name>
     <defaults>
       <allow_any>no</allow_any>

--- a/data/org.pantheon.switchboard.parental-controls.policy.in
+++ b/data/org.pantheon.switchboard.parental-controls.policy.in
@@ -7,7 +7,7 @@
   <vendor_url>https://elementary.io</vendor_url>
 
   <action id="org.pantheon.switchboard.parental-controls.administration">
-    <description gettext-domain="@GETTEXT_PACKAGE@">Manage Screen Time &amp; Limits settings</description>
+    <description gettext-domain="@GETTEXT_PACKAGE@">Manage Screen Time &amp; Limits</description>
     <message gettext-domain="@GETTEXT_PACKAGE@">Authentication is required to change Screen Time &amp; Limits settings</message>
     <icon_name>preferences-system-parental-controls</icon_name>
     <defaults>

--- a/data/org.pantheon.switchboard.parental-controls.policy.in
+++ b/data/org.pantheon.switchboard.parental-controls.policy.in
@@ -7,8 +7,8 @@
   <vendor_url>https://elementary.io</vendor_url>
 
   <action id="org.pantheon.switchboard.parental-controls.administration">
-    <description gettext-domain="@GETTEXT_PACKAGE@">Manage parental control settings</description>
-    <message gettext-domain="@GETTEXT_PACKAGE@">Authentication is required to change parental control settings</message>
+    <description gettext-domain="@GETTEXT_PACKAGE@">Manage Digital Wellbeing settings</description>
+    <message gettext-domain="@GETTEXT_PACKAGE@">Authentication is required to change Digital Wellbeing settings</message>
     <icon_name>preferences-system-parental-controls</icon_name>
     <defaults>
       <allow_any>no</allow_any>

--- a/data/org.pantheon.switchboard.parental-controls.policy.in
+++ b/data/org.pantheon.switchboard.parental-controls.policy.in
@@ -8,7 +8,7 @@
 
   <action id="org.pantheon.switchboard.parental-controls.administration">
     <description gettext-domain="@GETTEXT_PACKAGE@">Manage Screen Time &amp; Limits</description>
-    <message gettext-domain="@GETTEXT_PACKAGE@">Authentication is required to change Screen Time &amp; Limits settings</message>
+    <message gettext-domain="@GETTEXT_PACKAGE@">Authentication is required to change Screen Time &amp; Limits</message>
     <icon_name>preferences-system-parental-controls</icon_name>
     <defaults>
       <allow_any>no</allow_any>

--- a/data/pantheon-parental-controls-client.desktop.in
+++ b/data/pantheon-parental-controls-client.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
-Name=Parental Controls Client
+Name=Digital Wellbeing Client
 Exec=@CLIENT_PATH@
-Comment=Show parental control restrictions
+Comment=Show Digital Wellbeing information and restrictions
 Icon=preferences-system-parental-controls
 Terminal=false
 Type=Application

--- a/data/pantheon-parental-controls-client.desktop.in
+++ b/data/pantheon-parental-controls-client.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
-Name=Digital Wellbeing Client
+Name=Screen Time & Limits Client
 Exec=@CLIENT_PATH@
-Comment=Show Digital Wellbeing information and restrictions
+Comment=Show Screen Time & Limits information and restrictions
 Icon=preferences-system-parental-controls
 Terminal=false
 Type=Application

--- a/data/pantheon-parental-controls.service.in
+++ b/data/pantheon-parental-controls.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=Pantheon Digital Wellbeing Daemon
+Description=Pantheon Screen Time & Limits Daemon
 
 [Service]
 Type=dbus

--- a/data/pantheon-parental-controls.service.in
+++ b/data/pantheon-parental-controls.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=Pantheon Parental Controls Daemon
+Description=Pantheon Digital Wellbeing Daemon
 
 [Service]
 Type=dbus

--- a/debian/control
+++ b/debian/control
@@ -21,5 +21,5 @@ Package: switchboard-plug-parental-controls
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Enhances: switchboard
-Description: Manage Digital Wellbeing
- Switchboard plug for managing Digital Wellbeing.
+Description: Manage Screen Time & Limits
+ Switchboard plug for managing Screen Time & Limits.

--- a/debian/control
+++ b/debian/control
@@ -21,5 +21,5 @@ Package: switchboard-plug-parental-controls
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Enhances: switchboard
-Description: Manage parental controls
- Switchboard plug for managing parental controls.
+Description: Manage Digital Wellbeing
+ Switchboard plug for managing Digital Wellbeing.

--- a/src/plug/Plug.vala
+++ b/src/plug/Plug.vala
@@ -30,7 +30,7 @@ public class PC.Plug : Switchboard.Plug {
         Object (
             category: Category.SYSTEM,
             code_name: "pantheon-parental-controls",
-            display_name: _("Digital Wellbeing"),
+            display_name: _("Screen Time & Limits"),
             description: _("Configure time limits and restrict application usage"),
             icon: "preferences-system-parental-controls",
             supported_settings: settings
@@ -65,7 +65,7 @@ public class PC.Plug : Switchboard.Plug {
 }
 
 public Switchboard.Plug get_plug (Module module) {
-    debug ("Activating Parental Controls plug");
+    debug ("Activating Screen Time & Limits plug");
 
     var plug = new PC.Plug ();
     return plug;

--- a/src/plug/Plug.vala
+++ b/src/plug/Plug.vala
@@ -30,7 +30,7 @@ public class PC.Plug : Switchboard.Plug {
         Object (
             category: Category.SYSTEM,
             code_name: "pantheon-parental-controls",
-            display_name: _("Parental Control"),
+            display_name: _("Digital Wellbeing"),
             description: _("Configure time limits and restrict application usage"),
             icon: "preferences-system-parental-controls",
             supported_settings: settings

--- a/src/plug/Widgets/ControlPage.vala
+++ b/src/plug/Widgets/ControlPage.vala
@@ -48,7 +48,7 @@ namespace PC.Widgets {
             apps_box.expand = true;
 
             stack = new Gtk.Stack ();
-            stack.add_titled (time_limit_view, "general", _("Time Limits"));
+            stack.add_titled (time_limit_view, "general", _("Screen Time"));
             stack.add_titled (internet_box, "internet", _("Internet"));
             stack.add_titled (apps_box, "apps", _("Applications"));
 
@@ -72,7 +72,7 @@ namespace PC.Widgets {
             if (permission.allowed) {
                 Utils.get_api ().set_user_daemon_active.begin (user.get_user_name (), active);
                 time_limit_view.update_pam (active);
-            }  
+            }
         }
 
         public async bool get_active () {
@@ -81,8 +81,8 @@ namespace PC.Widgets {
             } catch (Error e) {
                 warning (e.message);
             }
-            
+
             return false;
-        } 
+        }
     }
 }


### PR DESCRIPTION
Fixes #45. Only touches user-facing strings, not filenames or codenames.