### PR TITLE
Sets 00:00 and 23:59 as default times for picker_to and picker_from.

### DIFF
--- a/src/plug/Views/TimeLimitView.vala
+++ b/src/plug/Views/TimeLimitView.vala
@@ -136,10 +136,19 @@ namespace PC.Widgets {
             enable_switch.valign = Gtk.Align.CENTER;
 
             var today_local = new GLib.DateTime.now_local ();
-            var today_start = new GLib.DateTime.local (today_local.get_year (), today_local.get_month (),
-                                                      today_local.get_day_of_month (), 0, 0, 0);
-            var today_end = new GLib.DateTime.local (today_local.get_year (), today_local.get_month (),
-                                                    today_local.get_day_of_month (), 23, 59, 59);
+            var today_start = new GLib.DateTime.local (
+                today_local.get_year (),
+                today_local.get_month (),
+                today_local.get_day_of_month (),
+                0, 0, 0
+            );
+
+            var today_end = new GLib.DateTime.local (
+                today_local.get_year (),
+                today_local.get_month (),
+                today_local.get_day_of_month (),
+                23, 59, 59
+            );
 
             var from_label = new Gtk.Label (_("From:"));
             from_label.halign = Gtk.Align.END;

--- a/src/plug/Views/TimeLimitView.vala
+++ b/src/plug/Views/TimeLimitView.vala
@@ -135,10 +135,10 @@ namespace PC.Widgets {
             enable_switch.halign = Gtk.Align.START;
             enable_switch.valign = Gtk.Align.CENTER;
 
-            var today_local = new GLib.DateTime.now_local();
-            var today_start = new GLib.DateTime.local(today_local.get_year (), today_local.get_month (), 
+            var today_local = new GLib.DateTime.now_local ();
+            var today_start = new GLib.DateTime.local (today_local.get_year (), today_local.get_month (),
                                                       today_local.get_day_of_month (), 0, 0, 0);
-            var today_end = new GLib.DateTime.local(today_local.get_year (), today_local.get_month (), 
+            var today_end = new GLib.DateTime.local (today_local.get_year (), today_local.get_month (),
                                                     today_local.get_day_of_month (), 23, 59, 59);
 
             var from_label = new Gtk.Label (_("From:"));

--- a/src/plug/Views/TimeLimitView.vala
+++ b/src/plug/Views/TimeLimitView.vala
@@ -135,16 +135,24 @@ namespace PC.Widgets {
             enable_switch.halign = Gtk.Align.START;
             enable_switch.valign = Gtk.Align.CENTER;
 
+            var today_local = new GLib.DateTime.now_local();
+            var today_start = new GLib.DateTime.local(today_local.get_year (), today_local.get_month (), 
+                                                      today_local.get_day_of_month (), 0, 0, 0);
+            var today_end = new GLib.DateTime.local(today_local.get_year (), today_local.get_month (), 
+                                                    today_local.get_day_of_month (), 23, 59, 59);
+
             var from_label = new Gtk.Label (_("From:"));
             from_label.halign = Gtk.Align.END;
 
             picker_from = new Granite.Widgets.TimePicker ();
             picker_from.hexpand = true;
+            picker_from.time = today_start;
 
             var to_label = new Gtk.Label (_("To:"));
 
             picker_to = new Granite.Widgets.TimePicker ();
             picker_to.hexpand = true;
+            picker_to.time = today_end;
 
             var label = new Gtk.Label (title);
             label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);


### PR DESCRIPTION
Fix #126 : sets 00:00 and 23:59 as default times for picker_to and picker_from. This avoids locking the current user out when enabling login restrictions based on time. 

![Screenshot from 2020-07-22 20-35-17](https://user-images.githubusercontent.com/221446/88239704-8b564b00-cc5b-11ea-8e89-65ddf9a3294d.png)

In the screenshot above, if a toggle is not selected then the accepted interval is always 00:00 to 23:59. 