### PR TITLE
Fix permission when loading plugin with apps

### DIFF
--- a/data/screentime-limits.policy.in.in
+++ b/data/screentime-limits.policy.in.in
@@ -17,8 +17,7 @@
     </defaults>
     <annotate key="org.freedesktop.policykit.exec.path">@CLIENT_PATH@</annotate>
     <annotate key="org.freedesktop.policykit.imply">org.freedesktop.parental-controls.user-administration</annotate>
-    <annotate key="org.freedesktop.policykit.imply">com.endlessm.ParentalControls.AppFilter.ChangeOwn</annotate>
-    <annotate key="org.freedesktop.policykit.imply">com.endlessm.ParentalControls.AppFilter.ChangeAny</annotate>
+    <annotate key="org.freedesktop.policykit.imply">com.endlessm.ParentalControls.AppFilter.ChangeAny com.endlessm.ParentalControls.AppFilter.ChangeOwn</annotate>
   </action>
 
 </policyconfig>

--- a/src/plug/Views/AppsView.vala
+++ b/src/plug/Views/AppsView.vala
@@ -227,7 +227,7 @@ namespace PC.Widgets {
 
             if (malcontent != null) {
                 try {
-                    app_filter = yield malcontent.get_app_filter_async (user.uid, Mct.ManagerGetValueFlags.NONE, null);
+                    app_filter = yield malcontent.get_app_filter_async ((int)Posix.getuid (), Mct.ManagerGetValueFlags.NONE, null);
                 } catch (Error e) {
                     warning ("Unable to get malcontent app filter: %s", e.message);
                 }


### PR DESCRIPTION
Hi!
Malcontent parental controls asks user for password when loading the plug.
Perhaps, you need these fixes.

**Before:**

![Peek 2021-11-29 02-17](https://user-images.githubusercontent.com/8833364/143790894-0a143db9-9b3c-4c65-a372-c175371a62ca.gif)

**After:**

![Peek 2021-11-29 02-19](https://user-images.githubusercontent.com/8833364/143790905-20ca13f7-d46d-4ea2-af17-a52abeea734e.gif)