### PR TITLE
Remove old dh-systemd transitional package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Dependencies
         run: |
           apt update
-          apt install -y dh-systemd libaccountsservice-dev libglib2.0-dev libgranite-dev libgtk-3-dev libhandy-1-dev libpolkit-gobject-1-dev libswitchboard-2.0-dev libdbus-1-dev policykit-1 libflatpak-dev libmalcontent-0-dev systemd meson valac
+          apt install -y debhelper libaccountsservice-dev libglib2.0-dev libgranite-dev libgtk-3-dev libhandy-1-dev libpolkit-gobject-1-dev libswitchboard-2.0-dev libdbus-1-dev policykit-1 libflatpak-dev libmalcontent-0-dev systemd meson valac
       - name: Build
         env:
           DESTDIR: out


### PR DESCRIPTION
These debhelper rules are in `debhelper` itself since >9