### PR TITLE
ControlPage: absorb infobar

### DIFF
--- a/src/plug/MainView.vala
+++ b/src/plug/MainView.vala
@@ -35,14 +35,7 @@ public class PC.MainBox : Gtk.Box {
             resize_start_child = false
         };
 
-        var lock_button = new Gtk.LockButton (Utils.get_permission ());
-
-        var infobar = new Gtk.InfoBar ();
-        infobar.add_child (new Gtk.Label (_("Some settings require administrator rights to be changed")));
-        infobar.add_action_widget (lock_button, 1);
-
         orientation = VERTICAL;
-        append (infobar);
         append (paned);
 
         list.row_activated.connect ((row) => {
@@ -53,9 +46,6 @@ public class PC.MainBox : Gtk.Box {
 
             stack.visible_child = user_item_row.page;
         });
-
-        unowned Polkit.Permission permission = Utils.get_permission ();
-        permission.bind_property ("allowed", infobar, "revealed", SYNC_CREATE | INVERT_BOOLEAN);
 
         unowned var user_manager = Act.UserManager.get_default ();
         user_manager.user_added.connect (add_user);

--- a/src/plug/Widgets/ControlPage.vala
+++ b/src/plug/Widgets/ControlPage.vala
@@ -56,11 +56,15 @@ public class PC.Widgets.ControlPage : Switchboard.SettingsPage {
 
         var lock_button = new Gtk.LockButton (Utils.get_permission ());
 
+        var infobar_label = new Gtk.Label (_("Some settings require administrator rights to be changed")) {
+            wrap = true
+        };
+
         var infobar = new Gtk.InfoBar () {
             margin_bottom = 9
         };
         infobar.add_css_class (Granite.STYLE_CLASS_FRAME);
-        infobar.add_child (new Gtk.Label (_("Some settings require administrator rights to be changed")));
+        infobar.add_child (infobar_label);
         infobar.add_action_widget (lock_button, 1);
 
         var box = new Gtk.Box (VERTICAL, 0);

--- a/src/plug/Widgets/ControlPage.vala
+++ b/src/plug/Widgets/ControlPage.vala
@@ -18,8 +18,6 @@ public class PC.Widgets.ControlPage : Switchboard.SettingsPage {
         );
     }
     construct {
-        unowned var permission = Utils.get_permission ();
-
         try {
             avatar_paintable = Gdk.Texture.from_filename (user.get_icon_file ());
         } catch (Error e) {
@@ -41,10 +39,6 @@ public class PC.Widgets.ControlPage : Switchboard.SettingsPage {
         stack.add_titled (internet_box, "internet", _("Internet"));
         stack.add_titled (apps_box, "apps", _("Applications"));
 
-        permission.bind_property ("allowed", time_limit_view, "sensitive", SYNC_CREATE);
-        permission.bind_property ("allowed", internet_box, "sensitive", SYNC_CREATE);
-        permission.bind_property ("allowed", apps_box, "sensitive", SYNC_CREATE);
-
         var switcher = new Gtk.StackSwitcher () {
             halign = CENTER,
             margin_bottom = 12,
@@ -59,11 +53,27 @@ public class PC.Widgets.ControlPage : Switchboard.SettingsPage {
             switcher_child = switcher_child.get_next_sibling ();
         }
 
+        var lock_button = new Gtk.LockButton (Utils.get_permission ());
+
+        var infobar = new Gtk.InfoBar () {
+            margin_bottom = 9
+        };
+        infobar.add_css_class (Granite.STYLE_CLASS_FRAME);
+        infobar.add_child (new Gtk.Label (_("Some settings require administrator rights to be changed")));
+        infobar.add_action_widget (lock_button, 1);
+
         var box = new Gtk.Box (VERTICAL, 0);
+        box.append (infobar);
         box.append (switcher);
         box.append (stack);
 
         child = box;
+
+        unowned var permission = Utils.get_permission ();
+        permission.bind_property ("allowed", infobar, "revealed", SYNC_CREATE | INVERT_BOOLEAN);
+        permission.bind_property ("allowed", time_limit_view, "sensitive", SYNC_CREATE);
+        permission.bind_property ("allowed", internet_box, "sensitive", SYNC_CREATE);
+        permission.bind_property ("allowed", apps_box, "sensitive", SYNC_CREATE);
     }
 
     public void set_active (bool active) {


### PR DESCRIPTION
![Screenshot from 2024-03-14 13 47 14](https://github.com/elementary/switchboard-plug-parental-controls/assets/7277719/77cff92a-930c-478f-b0d1-97491224cfd3)

Need to get this infobar off the top of the window because window controls will be there