### PR TITLE
Fix client quits immediately after launch

### DIFF
--- a/src/client/Client.vala
+++ b/src/client/Client.vala
@@ -97,6 +97,8 @@ namespace PC.Client {
 
             api.launch.connect (on_launch);
             api.show_timeout.connect (on_show_timeout);
+
+            hold ();
         }
 
         private void on_authorize (string username, string action_id, string[] _args) {


### PR DESCRIPTION
Fixes #215

## Before
```
user@elementary-8-daily:~$ ps aux | grep pantheon-parental-controls-client
user        2447  0.0  0.0  49852  2460 pts/0    S+   16:22   0:00 grep --color=auto pantheon-parental-controls-client
user@elementary-8-daily:~$ 
```

## After
```
user@elementary-8-daily:~$ ps aux | grep pantheon-parental-controls-client
user        1835  0.1  0.3 472164 29836 ?        Sl   16:23   0:00 /usr/lib/x86_64-linux-gnu/pantheon-parental-controls-client
user        2291  0.0  0.0  49852  2464 pts/0    S+   16:23   0:00 grep --color=auto pantheon-parental-controls-client
user@elementary-8-daily:~$ 
```