### PR TITLE
README: Fix wrong dependency name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ You'll need the following dependencies:
 * libmalcontent-0-dev
 * libpolkit-gobject-1-dev
 * libswitchboard-3-dev
-* libsystemd-dev
 * meson >= 0.58.0
+* systemd-dev
 * valac
 
 Run `meson` to configure the build environment and then `ninja` to build


### PR DESCRIPTION
c.f. The control file, which is actually used to build the package.

https://github.com/elementary/settings-screentime-limits/blob/f3040b41423799a4e821c0a0164cdbefb04bdc72/debian/control#L18
